### PR TITLE
Fix issue with Win32 typedef

### DIFF
--- a/include/AL/alext.h
+++ b/include/AL/alext.h
@@ -364,7 +364,7 @@ struct MOB_ConfigKeyValue_Struct;
 typedef void (AL_APIENTRY*LPALSETCONFIGMOB)(const struct MOB_ConfigKeyValue_Struct *);
 typedef ALboolean (AL_APIENTRY*LPALCDEVICEENABLEHRTFMOB)(ALCdevice*, ALboolean);
 #ifdef _WIN32
-typedef void (AL_APIENTRY*LPALCSETWINDOWMOB)(ALboolean);
+typedef void (AL_APIENTRY*LPALCSETWINDOWMOB)(HWND wnd);
 #endif // _WIN32
 
 #ifdef AL_ALEXT_PROTOTYPES


### PR DESCRIPTION
Updates the header to match the function declaration ([line 1054 in dsound.c](https://github.com/Jawbone/OpenAL-MOB/blob/dc319c990f9b0d4724d848d52ad4619b518c6e3c/Alc/backends/dsound.c#L1054)) to fix run time linking issues.
